### PR TITLE
Fix search field freeze on queries starting with \ or *

### DIFF
--- a/src/js/09-search-guard.js
+++ b/src/js/09-search-guard.js
@@ -13,19 +13,19 @@
 // prefix and contains wildcards automatically -- so we strip them from the input
 // before the search (bound on a debounced keydown) reads the value.
 document.addEventListener('DOMContentLoaded', function () {
-  const searchInput = document.getElementById('search-input')
-  if (!searchInput) return
+  document.addEventListener('input', function (e) {
+    const searchInput = e.target
+    if (!searchInput || searchInput.id !== 'search-input') return
 
-  searchInput.addEventListener('input', function () {
     const value = searchInput.value
     const cleaned = value.replace(/[\\*]/g, '')
     if (cleaned === value) return
 
     // Preserve the caret, accounting for characters removed before it.
-    const caret = searchInput.selectionStart || 0
+    const caret = searchInput.selectionStart ?? 0
     const removedBeforeCaret = (value.slice(0, caret).match(/[\\*]/g) || []).length
     searchInput.value = cleaned
-    const newCaret = caret - removedBeforeCaret
-    searchInput.setSelectionRange(newCaret, newCaret)
-  })
+    const newCaret = Math.max(0, caret - removedBeforeCaret)
+    try { searchInput.setSelectionRange(newCaret, newCaret) } catch {}
+  }, true)
 })

--- a/src/js/09-search-guard.js
+++ b/src/js/09-search-guard.js
@@ -1,0 +1,31 @@
+// Guards the lunr search field (#search-input) against queries that expand to a
+// match-all wildcard. Such queries return every document in the index, which
+// search-ui.js then renders unbounded on the main thread on every keystroke,
+// freezing the tab. See issue #36.
+//
+// Antora's lunr search-ui.js parses a `*` as a literal wildcard term and a `\`
+// as an empty term. The empty term yields no exact match, so its begins-with /
+// contains fallback appends `*` to the term. Either path produces a term that
+// matches every token in the index. Its try/catch only guards QueryParseError,
+// which is never thrown here, so nothing stops the blow-up.
+//
+// The user never needs to type these characters -- search-ui.js already applies
+// prefix and contains wildcards automatically -- so we strip them from the input
+// before the search (bound on a debounced keydown) reads the value.
+document.addEventListener('DOMContentLoaded', function () {
+  const searchInput = document.getElementById('search-input')
+  if (!searchInput) return
+
+  searchInput.addEventListener('input', function () {
+    const value = searchInput.value
+    const cleaned = value.replace(/[\\*]/g, '')
+    if (cleaned === value) return
+
+    // Preserve the caret, accounting for characters removed before it.
+    const caret = searchInput.selectionStart || 0
+    const removedBeforeCaret = (value.slice(0, caret).match(/[\\*]/g) || []).length
+    searchInput.value = cleaned
+    const newCaret = caret - removedBeforeCaret
+    searchInput.setSelectionRange(newCaret, newCaret)
+  })
+})


### PR DESCRIPTION
Fixes #36.

## Problem
The search field freezes when a query begins with `\` or `*`. The dev site uses Antora's lunr search (`@antora/lunr-extension`), not Algolia. `*` parses to a literal match-all wildcard term, and `\` parses to an empty term whose begins-with/contains fallback appends `*` — both expand via lunr's `TokenSet` to match every document in the index, which `search-ui.js` then renders unbounded on the main thread on every keystroke. Its `try/catch` only guards `QueryParseError`, which is never thrown for these inputs.

## Fix
`search-ui.js` ships from the lunr extension, but this UI owns `#search-input` and its `site.js` bundle loads before `search-ui.js`. Adds `src/js/09-search-guard.js`, which strips `*` and `\` from the input on `input`, before the debounced search reads the value (with caret preservation). Users never need to type these — search-ui.js applies prefix/contains wildcards automatically — so normal queries are unaffected.

## Verification
- `npx gulp bundle` succeeds; the guard is present in the built `site.js`.
- Ran the guard source through a DOM shim: leading `*`, leading `\`, interior `*`, and mixed paste are all stripped; normal queries and caret position are preserved (7/7 scenarios).
